### PR TITLE
feat: migrate bbox format to GeoJSON RFC 7946 standard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@
 # ============================================================================
 # Geographic Bounds
 # ============================================================================
-# Bounding box for forecast area: lat_min,lat_max,lon_min,lon_max
+# Bounding box following GeoJSON RFC 7946 format (lon_min,lat_min,lon_max,lat_max)
 # Example: Alps region
-PYPARAGLIDE_BBOX=45,47,13,15
+PYPARAGLIDE_BBOX=13,45,15,47
 
 # ============================================================================
 # Data Directories

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,7 +28,7 @@ print(f"GFS dir: {settings.gfs_dir}")
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `training_dates` | `str` | Date ranges (format: `YYYY-MM-DD:YYYY-MM-DD,...`) |
-| `bbox` | `str` | Bounding box (format: `lat_min,lat_max,lon_min,lon_max`) |
+| `bbox` | `str` | Bounding box following GeoJSON RFC 7946 (format: `lon_min,lat_min,lon_max,lat_max`) |
 | `gfs_dir` | `Path` | GFS data directory |
 | `pkl_dir` | `Path` | PKL dataset directory |
 | `flights_dir` | `Path` | Flight data directory |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -260,7 +260,7 @@ All configuration is done via environment variables with the `PYPARAGLIDE_` pref
 ```bash
 # Required
 PYPARAGLIDE_TRAINING_DATES=2024-06-01:2024-08-31,2025-06-01:2025-08-31
-PYPARAGLIDE_BBOX=45,47,13,15
+PYPARAGLIDE_BBOX=13,45,15,47  # Following GeoJSON RFC 7946 (lon_min,lat_min,lon_max,lat_max)
 PYPARAGLIDE_GFS_DIR=data/gfs/anl
 
 # Optional (with defaults)

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -32,8 +32,8 @@ Set your training parameters in `.env`:
 # Training dates (multiple seasons recommended)
 PYPARAGLIDE_TRAINING_DATES=2024-06-01:2024-08-31,2025-06-01:2025-08-31
 
-# Bounding box (Alps example)
-PYPARAGLIDE_BBOX=45,47,13,15
+# Bounding box following GeoJSON RFC 7946 (Alps example: lon_min,lat_min,lon_max,lat_max)
+PYPARAGLIDE_BBOX=13,45,15,47
 
 # Data directories
 PYPARAGLIDE_PKL_DIR=data/pkl

--- a/src/pyparaglide/analysis/flights_analyzer.py
+++ b/src/pyparaglide/analysis/flights_analyzer.py
@@ -67,7 +67,7 @@ class FlightAnalyzer:
         """
         Args:
             flights_dir: Directory with xContest JSON files
-            bbox: Optional filter (lat_min, lat_max, lon_min, lon_max)
+            bbox: Optional bounding box in GeoJSON RFC 7946 format (lon_min, lat_min, lon_max, lat_max)
         """
         self.flights_dir = Path(flights_dir)
         self.bbox = bbox
@@ -269,8 +269,8 @@ class FlightAnalyzer:
 
             # Check bbox (only if specified)
             if self.bbox:
-                lat_min, lat_max, lon_min, lon_max = self.bbox
-                if lat_min <= lat < lat_max and lon_min <= lon < lon_max:
+                lon_min, lat_min, lon_max, lat_max = self.bbox
+                if lon_min <= lon < lon_max and lat_min <= lat < lat_max:
                     inside_bbox += 1
                 else:
                     outside_bbox += 1

--- a/src/pyparaglide/cli/__init__.py
+++ b/src/pyparaglide/cli/__init__.py
@@ -126,7 +126,7 @@ app.add_typer(download_app, name="dl")
 @analyze_app.command()
 def flights(
     flights_dir: str = typer.Option(None, "--flights-dir", "-d", help="Flights directory"),
-    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box filter: lat_min,lat_max,lon_min,lon_max"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box in GeoJSON format (lon_min,lat_min,lon_max,lat_max)"),
     min_flights: int = typer.Option(0, "--min-flights", "-m", help="Min flights per spot"),
 ) -> None:
     """
@@ -142,7 +142,7 @@ def flights(
 
     Example:
         pyparaglide analyze flights
-        pyparaglide analyze flights --bbox 45,47,13,16 --min-flights 50
+        pyparaglide analyze flights --bbox 13,45,16,47 --min-flights 50
     """
     import datetime as dt
 
@@ -159,7 +159,7 @@ def flights(
             parsed_bbox = tuple(parts)
         else:
             console.print(f"[red]Invalid bbox format: {bbox}[/red]")
-            console.print("Expected: lat_min,lat_max,lon_min,lon_max")
+            console.print("Expected: lon_min,lat_min,lon_max,lat_max (GeoJSON format)")
             raise typer.Exit(1)
 
     # Create analyzer
@@ -269,13 +269,13 @@ Spots with >={min_flights} flights: {len(result.by_spot)}"""
         console.print(f"[bold]Detected Cell Clusters:[/bold]")
         table = Table(show_header=True, header_style="bold magenta")
         table.add_column("#", style="cyan")
-        table.add_column("BBox", style="green")
+        table.add_column("BBox (lon_min,lat_min,lon_max,lat_max)", style="green")
         table.add_column("Cells", style="yellow")
         table.add_column("Flights", style="yellow")
         table.add_column("Top Spot", style="blue")
 
         for i, cluster in enumerate(result.clusters[:5], 1):
-            bbox_str = f"{cluster.lat_min},{cluster.lat_max},{cluster.lon_min},{cluster.lon_max}"
+            bbox_str = f"{cluster.lon_min},{cluster.lat_min},{cluster.lon_max},{cluster.lat_max}"
             table.add_row(str(i), bbox_str, str(cluster.count), f"{cluster.flights:,}", cluster.top_spot[:20])
 
         console.print(table)
@@ -283,7 +283,8 @@ Spots with >={min_flights} flights: {len(result.by_spot)}"""
         # Best cluster recommendation
         best = result.clusters[0]
         console.print(f"\n[bold yellow]Recommended bbox for best cluster:[/bold yellow]")
-        console.print(f"  [cyan]--bbox {best.lat_min},{best.lat_max},{best.lon_min},{best.lon_max}[/cyan]")
+        console.print(f"  [cyan]--bbox {best.lon_min},{best.lat_min},{best.lon_max},{best.lat_max}[/cyan]")
+        console.print(f"  [dim](Format: lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946)[/dim]")
         console.print(f"  [dim]({best.flights:,} flights in {best.count} cells)[/dim]")
 
 
@@ -576,7 +577,7 @@ def download_forecast(
 @download_app.command("elevation")
 def download_elevation(
     data_dir: str = typer.Option(None, "--data-dir", "-o", help="Output directory for elevation files"),
-    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box: lat_min,lat_max,lon_min,lon_max"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box in GeoJSON format (lon_min,lat_min,lon_max,lat_max)"),
 ) -> None:
     """
     Download SRTM elevation data.
@@ -585,7 +586,7 @@ def download_elevation(
 
     Examples:
         pyparaglide download elevation
-        pyparaglide download elevation --bbox 45,47,13,15
+        pyparaglide download elevation --bbox 13,45,15,47
     """
     from pyparaglide.cli._download_helpers import download_elevation_impl
 
@@ -1126,7 +1127,7 @@ def forecast(
     models_dir: str = typer.Option(None, "--models-dir", help="Directory with model weights"),
     grib_dir: str = typer.Option(None, "--grib-dir", "-g", help="Directory containing GRIB files"),
     output_dir: str = typer.Option(None, "--output-dir", "-o", help="Output directory for forecasts"),
-    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box: lat_min,lat_max,lon_min,lon_max"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box in GeoJSON format (lon_min,lat_min,lon_max,lat_max)"),
 ) -> None:
     """
     Generate paragliding flyability forecast using CELLS model.
@@ -1286,7 +1287,7 @@ def build_dataset(
     gfs_dir: str = typer.Option(None, "--gfs-dir", help="Directory containing GFS GRIB files"),
     flights_dir: str = typer.Option(None, "--flights-dir", help="Directory with xContest JSON files"),
     output_dir: str = typer.Option(None, "--output-dir", "-o", help="Output directory for PKL files"),
-    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box: lat_min,lat_max,lon_min,lon_max"),
+    bbox: str = typer.Option(None, "--bbox", "-b", help="Bounding box in GeoJSON format (lon_min,lat_min,lon_max,lat_max)"),
     min_flights: int = typer.Option(200, "--min-flights", help="Minimum flights per spot"),
     min_cells: int = typer.Option(None, "--min-cells", help="Minimum flights per cell for training (0=no filter, default from .env)"),
     no_flights: bool = typer.Option(False, "--no-flights", help="Skip flight data processing"),
@@ -1429,20 +1430,21 @@ Spots with >={min_flights} flights: {len(flight_result.by_spot)}"""
                 if flight_result.clusters:
                     console.print(f"\n[bold]Top Clusters:[/bold]")
                     table = Table(show_header=True, header_style="bold magenta")
-                    table.add_column("BBox", style="green")
+                    table.add_column("BBox (lon_min,lat_min,lon_max,lat_max)", style="green")
                     table.add_column("Cells", style="yellow")
                     table.add_column("Flights", style="yellow")
                     table.add_column("Top Spot", style="blue")
 
                     for cluster in flight_result.clusters[:3]:
-                        bbox_str = f"{cluster.lat_min},{cluster.lat_max},{cluster.lon_min},{cluster.lon_max}"
+                        bbox_str = f"{cluster.lon_min},{cluster.lat_min},{cluster.lon_max},{cluster.lat_max}"
                         table.add_row(bbox_str, str(cluster.count), f"{cluster.flights:,}", cluster.top_spot[:20])
 
                     console.print(table)
 
                     # Recommendation
                     best = flight_result.clusters[0]
-                    console.print(f"\n[bold yellow]Recommended bbox:[/bold yellow] [cyan]{best.lat_min},{best.lat_max},{best.lon_min},{best.lon_max}[/cyan]")
+                    console.print(f"\n[bold yellow]Recommended bbox:[/bold yellow] [cyan]{best.lon_min},{best.lat_min},{best.lon_max},{best.lat_max}[/cyan]")
+                    console.print(f"[dim](Format: lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946)[/dim]")
                     console.print(f"[dim]({best.flights:,} flights in {best.count} cells)[/dim]")
             except ValueError as e:
                 console.print(f"[yellow]Flight analysis skipped: {e}[/yellow]")

--- a/src/pyparaglide/cli/_download_helpers.py
+++ b/src/pyparaglide/cli/_download_helpers.py
@@ -116,7 +116,7 @@ def download_elevation_impl(data_dir: str | None, bbox: str | None) -> None:
 
     Args:
         data_dir: Output directory for elevation files
-        bbox: Bounding box string (lat_min,lat_max,lon_min,lon_max)
+        bbox: Bounding box string in GeoJSON format (lon_min,lat_min,lon_max,lat_max)
     """
     settings = get_settings()
 
@@ -132,7 +132,7 @@ def download_elevation_impl(data_dir: str | None, bbox: str | None) -> None:
         parts = [float(x.strip()) for x in bbox.split(",")]
         if len(parts) != 4:
             console.print(f"[red]Invalid bbox format: {bbox}[/red]")
-            console.print("Expected: lat_min,lat_max,lon_min,lon_max")
+            console.print("Expected: lon_min,lat_min,lon_max,lat_max (GeoJSON format)")
             raise typer.Exit(1)
         bbox_tuple = (parts[0], parts[1], parts[2], parts[3])
 

--- a/src/pyparaglide/config/__init__.py
+++ b/src/pyparaglide/config/__init__.py
@@ -75,8 +75,8 @@ class Settings(BaseSettings):
     # ==============================================================================
     # Geographic Bounds
     # ==============================================================================
-    # Bounding box for forecast area: lat_min,lat_max,lon_min,lon_max
-    bbox: str = "45,47,13,15"
+    # Bounding box in GeoJSON RFC 7946 format (lon_min,lat_min,lon_max,lat_max)
+    bbox: str = "13,45,15,47"
 
     # ==============================================================================
     # Data Directories
@@ -147,11 +147,34 @@ class Settings(BaseSettings):
     workers: int = 4
 
     def parse_bbox(self) -> tuple[float, float, float, float]:
-        """Parse bbox string into (lat_min, lat_max, lon_min, lon_max)."""
+        """Parse bbox string into (lon_min, lat_min, lon_max, lat_max) following GeoJSON RFC 7946."""
         parts = [float(x.strip()) for x in self.bbox.split(",")]
         if len(parts) != 4:
             raise ValueError(f"Invalid bbox format: {self.bbox}")
-        return parts[0], parts[1], parts[2], parts[3]
+
+        lon_min, lat_min, lon_max, lat_max = parts
+
+        # Validate coordinate ranges
+        if not (-180 <= lon_min <= 180 and -180 <= lon_max <= 180):
+            raise ValueError(f"Invalid longitude in bbox (must be -180..180): {self.bbox}")
+        if not (-90 <= lat_min <= 90 and -90 <= lat_max <= 90):
+            raise ValueError(f"Invalid latitude in bbox (must be -90..90): {self.bbox}")
+
+        # Validate order (detect old format usage)
+        if lon_min >= lon_max:
+            raise ValueError(
+                f"Invalid bbox: lon_min ({lon_min}) >= lon_max ({lon_max}). "
+                f"Bbox must be in GeoJSON format: lon_min,lat_min,lon_max,lat_max. "
+                f"If you're migrating from old format (lat_min,lat_max,lon_min,lon_max), "
+                f"update your .env file."
+            )
+        if lat_min >= lat_max:
+            raise ValueError(
+                f"Invalid bbox: lat_min ({lat_min}) >= lat_max ({lat_max}). "
+                f"Bbox must be in GeoJSON format: lon_min,lat_min,lon_max,lat_max."
+            )
+
+        return lon_min, lat_min, lon_max, lat_max
 
     def parse_training_dates(self) -> list[tuple[str, str]]:
         """

--- a/src/pyparaglide/downloads/elevation_downloader.py
+++ b/src/pyparaglide/downloads/elevation_downloader.py
@@ -39,7 +39,7 @@ class ElevationDownloader:
 
         Args:
             data_dir: Directory for elevation data storage
-            bbox: Bounding box (lat_min, lat_max, lon_min, lon_max)
+            bbox: Bounding box following GeoJSON RFC 7946 (lon_min, lat_min, lon_max, lat_max)
             product: SRTM1 (30m) or SRTM3 (90m)
             max_retries: Maximum download retry attempts
         """
@@ -74,7 +74,7 @@ class ElevationDownloader:
             "output_size_mb": 0,
         }
 
-        lat_min, lat_max, lon_min, lon_max = self.bbox
+        lon_min, lat_min, lon_max, lat_max = self.bbox
 
         print(f"\n=== Downloading {self.product} elevation data ===")
         print(f"  BBox: {lat_min:.2f}°N to {lat_max:.2f}°N, {lon_min:.2f}°E to {lon_max:.2f}°E")
@@ -144,7 +144,7 @@ class ElevationDownloader:
         - SRTM3: tiles are 5°x5°, CGIAR naming: srtm_{col}_{row}.zip
                  col/row are grid indices: col=(lon+185)//5, row=(lat+70)//5
         """
-        lat_min, lat_max, lon_min, lon_max = self.bbox
+        lon_min, lat_min, lon_max, lat_max = self.bbox
 
         tiles = []
 
@@ -211,19 +211,19 @@ class ElevationDownloader:
 
     def _validate_coverage(self) -> None:
         """Validate bbox is within SRTM coverage and warn if outside."""
-        lat_min, lat_max, lon_min, lon_max = self.bbox
+        lon_min, lat_min, lon_max, lat_max = self.bbox
 
         if lat_min < -60 or lat_max > 60:
             print(f"\n[WARNING] SRTM coverage limited to ±60° latitude")
             print(f"  Your bbox: {lat_min}° to {lat_max}°")
             print(f"  Data will be clipped to valid range")
 
-        # Clip to valid range
+        # Clip to valid range (following GeoJSON RFC 7946)
         self.bbox = (
-            max(lat_min, -60),
-            min(lat_max, 60),
             lon_min,  # Longitude has full -180 to +180 coverage
+            max(lat_min, -60),
             lon_max,
+            min(lat_max, 60),
         )
 
     def _download_tile(self, lat: int, lon: int) -> Path | None:

--- a/src/pyparaglide/inference/forecast.py
+++ b/src/pyparaglide/inference/forecast.py
@@ -141,7 +141,7 @@ class Forecaster:
         Args:
             grib_files: List of GRIB files (6h, 12h, 18h forecasts)
             target_date: Target date for forecast
-            bbox: Bounding box (lat_min, lat_max, lon_min, lon_max)
+            bbox: Bounding box following GeoJSON RFC 7946 (lon_min, lat_min, lon_max, lat_max)
 
         Returns:
             Dictionary with forecast results
@@ -298,7 +298,7 @@ class Forecaster:
         """Format CELLS prediction results into output dictionary."""
         results = {
             "date": target_date.isoformat(),
-            "bbox": {"lat_min": bbox[0], "lat_max": bbox[1], "lon_min": bbox[2], "lon_max": bbox[3]},
+            "bbox": {"lon_min": bbox[0], "lat_min": bbox[1], "lon_max": bbox[2], "lat_max": bbox[3]},
             "model_type": "CELLS",
             "predictions": [],
         }

--- a/src/pyparaglide/inference/grib_reader.py
+++ b/src/pyparaglide/inference/grib_reader.py
@@ -101,7 +101,7 @@ class GribReader:
 
         Args:
             name: Parameter name (e.g., 'Temperature', 'U component of wind')
-            bbox: (lat_min, lat_max, lon_min, lon_max)
+            bbox: (lon_min, lat_min, lon_max, lat_max) following GeoJSON RFC 7946
             level: Pressure level in hPa
             type_of_level: Type of level ('isobaricInhPa' for pressure levels)
 
@@ -118,8 +118,8 @@ class GribReader:
         if data is None:
             return None
 
-        # Find indices for bbox
-        lat_min, lat_max, lon_min, lon_max = bbox
+        # Find indices for bbox (following GeoJSON RFC 7946)
+        lon_min, lat_min, lon_max, lat_max = bbox
 
         # Handle longitude wrapping
         if lon_min < 0:

--- a/src/pyparaglide/preprocessing/dataset_builder.py
+++ b/src/pyparaglide/preprocessing/dataset_builder.py
@@ -50,13 +50,13 @@ class DatasetBuilder:
             gfs_dir: Directory containing GFS GRIB files
             flights_dir: Directory containing xContest JSON files
             output_dir: Output directory for PKL files
-            bbox: Bounding box (lat_min, lat_max, lon_min, lon_max)
+            bbox: Bounding box following GeoJSON RFC 7946 (lon_min, lat_min, lon_max, lat_max)
             elevation_dir: Directory containing elevation tiles
         """
         self.gfs_dir = Path(gfs_dir)
         self.flights_dir = Path(flights_dir)
         self.output_dir = Path(output_dir)
-        self.bbox = bbox or (45.0, 47.0, 13.0, 15.0)  # Alps region
+        self.bbox = bbox or (13.0, 45.0, 15.0, 47.0)  # Alps region (following GeoJSON RFC 7946)
         self.elevation_dir = Path(elevation_dir) if elevation_dir else None
 
         self.output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/pyparaglide/preprocessing/flights/flight_processor.py
+++ b/src/pyparaglide/preprocessing/flights/flight_processor.py
@@ -265,9 +265,9 @@ def cluster_nearby_spots(spots: Dict[str, Dict],
 
 
 def is_within_bbox(lat: float, lon: float, bbox: Tuple[float, float, float, float]) -> bool:
-    """Check if coordinates are within bounding box."""
-    lat_min, lat_max, lon_min, lon_max = bbox
-    return lat_min <= lat < lat_max and lon_min <= lon < lon_max
+    """Check if coordinates are within bounding box (bbox format: lon_min, lat_min, lon_max, lat_max following GeoJSON RFC 7946)."""
+    lon_min, lat_min, lon_max, lat_max = bbox
+    return lon_min <= lon < lon_max and lat_min <= lat < lat_max
 
 
 def _is_date_in_ranges(target_date: date, ranges: List[Tuple[date, date]]) -> bool:

--- a/src/pyparaglide/preprocessing/phases/cells_phase.py
+++ b/src/pyparaglide/preprocessing/phases/cells_phase.py
@@ -21,7 +21,7 @@ class BuildCellsPhase:
                  force: bool = False):
         """
         Args:
-            bbox: (lat_min, lat_max, lon_min, lon_max)
+            bbox: Bounding box following GeoJSON RFC 7946 (lon_min, lat_min, lon_max, lat_max)
             gfs_dir: Path to GFS GRIB files
             out_dir: Output directory for PKL files
             force: Force rebuild even if PKL files exist
@@ -62,7 +62,7 @@ class BuildCellsPhase:
                 print(f"  Config mismatch: saved bbox = {saved_metadata.get('bbox')}")
                 print("  Rebuilding with new bbox...")
 
-        lat_min, lat_max, lon_min, lon_max = self.bbox
+        lon_min, lat_min, lon_max, lat_max = self.bbox
 
         # Generate 1x1 degree cells
         # Note: bbox defines cell centers, so 45,46,12,13 creates 1 cell at (45,12)

--- a/src/pyparaglide/preprocessing/phases/terrain_phase.py
+++ b/src/pyparaglide/preprocessing/phases/terrain_phase.py
@@ -156,4 +156,5 @@ class BuildTerrainPhase:
         lon_min = max(-180, min(180, lon_min))
         lon_max = max(-180, min(180, lon_max))
 
-        return (lat_min, lat_max, lon_min, lon_max)
+        # Return in GeoJSON RFC 7946 format (lon_min, lat_min, lon_max, lat_max)
+        return (lon_min, lat_min, lon_max, lat_max)

--- a/tests/test_flights_analyzer.py
+++ b/tests/test_flights_analyzer.py
@@ -194,7 +194,7 @@ def test_analyze_with_bbox_filter(sample_flights: Path):
     """Test analysis with bbox filter."""
     analyzer = FlightAnalyzer(
         flights_dir=sample_flights,
-        bbox=(45.0, 46.0, 13.5, 14.5),  # Only Lijak (45.8, 13.9) inside
+        bbox=(13.5, 45.0, 14.5, 46.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946 - Only Lijak (45.8, 13.9) inside
     )
     result = analyzer.analyze(min_flights_threshold=0)
 

--- a/tests/test_meteo_phase.py
+++ b/tests/test_meteo_phase.py
@@ -56,7 +56,7 @@ class TestScanMeteoDaysQuick:
     def test_scan_finds_complete_days(self, temp_gfs_dir, temp_output_dir, sample_cells_latlon):
         """Test that quick scan finds only complete days."""
         phase = BuildMeteoPhase(
-            bbox=(45.0, 47.0, 13.0, 15.0),
+            bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
             gfs_dir=temp_gfs_dir,
             cells_latlon=sample_cells_latlon,
             out_dir=temp_output_dir,
@@ -75,7 +75,7 @@ class TestScanMeteoDaysQuick:
         empty_gfs_dir.mkdir()
 
         phase = BuildMeteoPhase(
-            bbox=(45.0, 47.0, 13.0, 15.0),
+            bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
             gfs_dir=empty_gfs_dir,
             cells_latlon=sample_cells_latlon,
             out_dir=temp_output_dir,
@@ -119,7 +119,7 @@ class TestAutoDetectionNewDays:
             with patch.object(BuildMeteoPhase, '_build_meteo_params') as mock_params:
                 mock_params.return_value = meteo_params
                 phase = BuildMeteoPhase(
-                    bbox=(45.0, 47.0, 13.0, 15.0),
+                    bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
                     gfs_dir=temp_gfs_dir,
                     cells_latlon=sample_cells_latlon,
                     out_dir=temp_output_dir,
@@ -165,7 +165,7 @@ class TestAutoDetectionNewDays:
             with patch.object(BuildMeteoPhase, '_build_meteo_params') as mock_params:
                 mock_params.return_value = meteo_params
                 phase = BuildMeteoPhase(
-                    bbox=(45.0, 47.0, 13.0, 15.0),
+                    bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
                     gfs_dir=temp_gfs_dir,
                     cells_latlon=sample_cells_latlon,
                     out_dir=temp_output_dir,
@@ -202,7 +202,7 @@ class TestAutoDetectionNewDays:
             with patch.object(BuildMeteoPhase, '_build_meteo_params') as mock_params:
                 mock_params.return_value = meteo_params
                 phase = BuildMeteoPhase(
-                    bbox=(45.0, 47.0, 13.0, 15.0),
+                    bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
                     gfs_dir=temp_gfs_dir,
                     cells_latlon=sample_cells_latlon,
                     out_dir=temp_output_dir,
@@ -236,7 +236,7 @@ class TestScanMeteoDaysDetailed:
             grb_file.write_bytes(b"fake grib content")
 
         phase = BuildMeteoPhase(
-            bbox=(45.0, 47.0, 13.0, 15.0),
+            bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
             gfs_dir=temp_gfs_dir,
             cells_latlon=sample_cells_latlon,
             out_dir=temp_output_dir,
@@ -265,7 +265,7 @@ class TestScanMeteoDaysDetailed:
                     grb_file.write_bytes(b"fake grib content")
 
         phase = BuildMeteoPhase(
-            bbox=(45.0, 47.0, 13.0, 15.0),
+            bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
             gfs_dir=temp_gfs_dir,
             cells_latlon=sample_cells_latlon,
             out_dir=temp_output_dir,
@@ -316,7 +316,7 @@ class TestAutoDetectionIntegration:
             with patch.object(BuildMeteoPhase, '_build_meteo_params') as mock_params:
                 mock_params.return_value = meteo_params
                 phase = BuildMeteoPhase(
-                    bbox=(45.0, 47.0, 13.0, 15.0),
+                    bbox=(13.0, 45.0, 15.0, 47.0),  # lon_min,lat_min,lon_max,lat_max following GeoJSON RFC 7946
                     gfs_dir=temp_gfs_dir,
                     cells_latlon=sample_cells_latlon,
                     out_dir=temp_output_dir,


### PR DESCRIPTION
## Summary

Migrates bbox (bounding box) format from proprietary `(lat_min, lat_max, lon_min, lon_max)` to **GeoJSON RFC 7946** standard `(lon_min, lat_min, lon_max, lat_max)`.

## Breaking Change

**Users must update their `.env` file:**

```bash
# Old format (no longer works):
PYPARAGLIDE_BBOX=45,47,13,15

# New format (GeoJSON RFC 7946):
PYPARAGLIDE_BBOX=13,45,15,47
```

Format: `lon_min,lat_min,lon_max,lat_max` (west, south, east, north)

## What Changed

- ✅ Updated bbox parsing in `Settings.parse_bbox()` with validation
- ✅ Updated all bbox usage across 18 files
- ✅ Added validation to detect old format and provide helpful error messages
- ✅ Updated CLI help text for all `--bbox` options
- ✅ Updated documentation (API.md, TRAINING.md, ARCHITECTURE.md)
- ✅ Updated all tests (149 tests passing)
- ✅ Added format clarification in CLI output

## Validation

The new bbox parser validates:
1. Coordinate ranges (lat: -90..90, lon: -180..180)
2. Coordinate order (min < max)
3. Provides helpful error messages for old format detection

## Files Changed

- Configuration: `src/pyparaglide/config/__init__.py`
- CLI: `src/pyparaglide/cli/__init__.py`, `_download_helpers.py`
- Core: `flight_processor.py`, `dataset_builder.py`, cells_phase.py`, terrain_phase.py
- Inference: `forecast.py`, `grib_reader.py`, `elevation_downloader.py`, `flights_analyzer.py`
- Tests: `test_flights_analyzer.py`, `test_meteo_phase.py`
- Docs: `.env.example`, `API.md`, `TRAINING.md`, `ARCHITECTURE.md`

## Migration Note for Existing Users

After this change, GRIB cache will be automatically invalidated and rebuilt on first run. This is expected and correct.

Users need to update their `.env` file with the new bbox format.